### PR TITLE
rust ci: install modern python on macos

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
       - name: Install breezy
         run: pip install breezy
       - name: Build


### PR DESCRIPTION
rust ci: install modern python on macos
