### PR TITLE
Fix spelling errors

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
+level of experience, education, socioeconomic status, nationality, personal
 appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards

--- a/readme_tests/aiozipkin/README.rst
+++ b/readme_tests/aiozipkin/README.rst
@@ -157,7 +157,7 @@ Jaeger support
 jaeger_ supports zipkin_ span format as result it is possible to use *aiozipkin*
 with jaeger_ server. You just need to specify *jaeger* server address and it
 should work out of the box. Not need to run local zipkin server.
-For more informations see tests and jaeger_ documentation.
+For more information see tests and jaeger_ documentation.
 
 .. image:: https://raw.githubusercontent.com/aio-libs/aiozipkin/master/docs/jaeger.png
     :alt: jaeger ui animation

--- a/readme_tests/argparse/README.rst
+++ b/readme_tests/argparse/README.rst
@@ -163,7 +163,7 @@ Config File Syntax
 
 Only command line args that have a long version (eg. one that starts with '--')
 can be set in a config file. For example, "--color" can be set by putting
-"color=green" in a config file. The config file syntax depends on the constuctor
+"color=green" in a config file. The config file syntax depends on the constructor
 arg: :code:`config_file_parser_class` which can be set to one of the provided
 classes: :code:`DefaultConfigFileParser`, :code:`YAMLConfigFileParser`,
 :code:`ConfigparserConfigFileParser` or to your own subclass of the

--- a/readme_tests/bup/README.md
+++ b/readme_tests/bup/README.md
@@ -8,7 +8,7 @@ this time?  Me neither.
 Despite its unassuming name, bup is pretty cool.  To give you an idea of
 just how cool it is, I wrote you this poem:
 
-                             Bup is teh awesome
+                             Bup is the awesome
                           What rhymes with awesome?
                             I guess maybe possum
                            But that's irrelevant.

--- a/readme_tests/bup/description
+++ b/readme_tests/bup/description
@@ -5,7 +5,7 @@ this time?  Me neither.
 Despite its unassuming name, bup is pretty cool.  To give you an idea of
 just how cool it is, I wrote you this poem:
 
-                         Bup is teh awesome
+                         Bup is the awesome
                       What rhymes with awesome?
                         I guess maybe possum
                        But that's irrelevant.

--- a/readme_tests/perl-timedate/README
+++ b/readme_tests/perl-timedate/README
@@ -3,7 +3,7 @@ or later
 
 This distribution replaces my earlier GetDate distribution, which was
 only a date parser. The date parser contained in this distribution is
-far superior to the yacc based parser, and a *lot* fatser.
+far superior to the yacc based parser, and a *lot* faster.
 
 The parser contained here will only parse absolute dates, if you want a
 date parser that can parse relative dates then take a look at the Time

--- a/readme_tests/perl-timedate/description
+++ b/readme_tests/perl-timedate/description
@@ -3,7 +3,7 @@ or later
 
 This distribution replaces my earlier GetDate distribution, which was
 only a date parser. The date parser contained in this distribution is
-far superior to the yacc based parser, and a *lot* fatser.
+far superior to the yacc based parser, and a *lot* faster.
 
 The parser contained here will only parse absolute dates, if you want a
 date parser that can parse relative dates then take a look at the Time

--- a/src/providers/ruby.rs
+++ b/src/providers/ruby.rs
@@ -127,7 +127,7 @@ pub async fn guess_from_gemspec(
             }
         } else {
             debug!(
-                "ignoring unparseable line in {}: {:?}",
+                "ignoring unparsable line in {}: {:?}",
                 path.display(),
                 line
             );

--- a/src/testdata/pecl.html
+++ b/src/testdata/pecl.html
@@ -111,7 +111,7 @@
                     <td valign="top" style="background-color: #e8e8e8">
                                                     Eduardo Bacchi Kienetz                                                        (lead)
                                                                                     [<a href="/user/eduardo">details</a>]<br>
-                                                    Remi Collet                                                        (contributor)
+                                                    Remi Collect                                                        (contributor)
                                                                                     [<a href="/user/remi">details</a>]<br>
                                             </td>
                 </tr>


### PR DESCRIPTION
Fix spelling errors
Used config files:
    1: .codespellrc

-------8<-------
SUMMARY:
collet        1
constuctor    1
fatser        2
informations  1
socio-economic1
teh           2
unparseable   1
