### PR TITLE
crates.io: Move away from the old REST API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5922,6 +5922,7 @@ name = "upstream-ontologist"
 version = "0.3.18"
 dependencies = [
  "async-trait",
+ "base64",
  "bit-set",
  "bit-vec",
  "breezyshim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ async-trait = ">=0.1.89, <0.2"
 tokio = { version = ">=1.47.1, <2", features = ["full"] }
 futures = ">=0.3.31, <0.4"
 debversion = { version = ">=0.4.7, <0.6", optional = true }
+base64 = "0.22.1"
 
 [features]
 default = ["git-config", "launchpad", "opam", "dist-ini", "cargo", "r-description", "pyproject-toml", "python-pkginfo", "debian", "pyo3", "setup-cfg", "breezy"]

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,0 +1,246 @@
+//! Helpers for accessing the GitHub API and raw repository files.
+//!
+//! Several providers need to talk to GitHub, either to query the REST API
+//! (`api.github.com`) or to download individual files. These helpers
+//! centralise that access, including authentication via the `GITHUB_TOKEN`
+//! environment variable, so call sites do not each reimplement it.
+
+use crate::{HTTPJSONError, UpstreamDatum};
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION};
+
+/// Base URL of the GitHub REST API.
+const API_BASE: &str = "https://api.github.com";
+
+/// Base URL for raw file access.
+const RAW_BASE: &str = "https://raw.githubusercontent.com";
+
+/// Builds the header map for a GitHub API request, adding an `Authorization`
+/// header when `GITHUB_TOKEN` is set in the environment.
+fn auth_headers(accept: &'static str) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(ACCEPT, HeaderValue::from_static(accept));
+    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+        if let Ok(value) = HeaderValue::from_str(&format!("Bearer {}", token)) {
+            headers.insert(AUTHORIZATION, value);
+        }
+    }
+    headers
+}
+
+async fn fetch(url: &str, accept: &'static str) -> Result<reqwest::Response, HTTPJSONError> {
+    let client = crate::http::build_client()
+        .default_headers(auth_headers(accept))
+        .build()
+        .map_err(HTTPJSONError::HTTPError)?;
+
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(HTTPJSONError::HTTPError)?;
+
+    if !response.status().is_success() {
+        return Err(HTTPJSONError::Error {
+            url: response.url().clone(),
+            status: response.status().as_u16(),
+            response: Box::new(response),
+        });
+    }
+
+    Ok(response)
+}
+
+/// Fetches a GitHub REST API endpoint and parses the response as JSON.
+///
+/// `path` is the API path without the host, e.g. `repos/serde-rs/serde` or
+/// `repos/serde-rs/serde/tags`. The `GITHUB_TOKEN` environment variable, if
+/// set, is sent as a bearer token to raise the rate limit.
+pub async fn load_github_json(path: &str) -> Result<serde_json::Value, HTTPJSONError> {
+    let url = format!("{}/{}", API_BASE, path.trim_start_matches('/'));
+    let response = fetch(&url, "application/vnd.github+json").await?;
+    response.json().await.map_err(HTTPJSONError::HTTPError)
+}
+
+/// Downloads a raw file from a repository via `raw.githubusercontent.com`.
+///
+/// This does not consume the API rate limit, but the caller must know the
+/// branch or tag (`reference`) and exact `path`; a missing file or wrong
+/// reference yields a 404.
+pub async fn download_raw_file(
+    owner: &str,
+    repo: &str,
+    reference: &str,
+    path: &str,
+) -> Result<String, HTTPJSONError> {
+    let url = format!(
+        "{}/{}/{}/{}/{}",
+        RAW_BASE,
+        owner,
+        repo,
+        reference,
+        path.trim_start_matches('/')
+    );
+    let response = fetch(&url, "text/plain").await?;
+    response.text().await.map_err(HTTPJSONError::HTTPError)
+}
+
+/// Downloads a file via the GitHub contents API.
+///
+/// Unlike [`download_raw_file`] this resolves the repository's default branch
+/// automatically when `reference` is `None`, at the cost of consuming the API
+/// rate limit. The base64-encoded content returned by the API is decoded.
+pub async fn download_contents(
+    owner: &str,
+    repo: &str,
+    path: &str,
+    reference: Option<&str>,
+) -> Result<Vec<u8>, crate::ProviderError> {
+    let mut url = format!(
+        "{}/repos/{}/{}/contents/{}",
+        API_BASE,
+        owner,
+        repo,
+        path.trim_start_matches('/')
+    );
+    if let Some(reference) = reference {
+        url.push_str(&format!("?ref={}", reference));
+    }
+
+    let response = fetch(&url, "application/vnd.github+json").await?;
+    let data: serde_json::Value = response.json().await.map_err(HTTPJSONError::HTTPError)?;
+
+    let encoding = data["encoding"].as_str();
+    let content = data["content"].as_str().ok_or_else(|| {
+        crate::ProviderError::ParseError("contents API response missing content".to_string())
+    })?;
+
+    match encoding {
+        Some("base64") => {
+            use base64::Engine;
+            // The API wraps the base64 payload at column 60 with newlines.
+            let stripped: String = content.chars().filter(|c| !c.is_whitespace()).collect();
+            base64::engine::general_purpose::STANDARD
+                .decode(stripped.as_bytes())
+                .map_err(|e| {
+                    crate::ProviderError::ParseError(format!("invalid base64 content: {}", e))
+                })
+        }
+        other => Err(crate::ProviderError::ParseError(format!(
+            "unexpected contents encoding: {:?}",
+            other
+        ))),
+    }
+}
+
+/// Repository metadata returned by the GitHub repos API.
+///
+/// This covers the fields useful as upstream metadata; the API returns many
+/// more that are ignored here.
+#[derive(serde::Deserialize, Debug, Clone)]
+pub struct RepoMetadata {
+    /// Repository description.
+    pub description: Option<String>,
+    /// Homepage URL declared on the repository.
+    pub homepage: Option<String>,
+    /// Canonical repository URL.
+    pub html_url: Option<String>,
+    /// License information, if GitHub detected one.
+    pub license: Option<License>,
+    /// Whether the repository is archived.
+    #[serde(default)]
+    pub archived: bool,
+}
+
+/// License information from the GitHub repos API.
+#[derive(serde::Deserialize, Debug, Clone)]
+pub struct License {
+    /// SPDX identifier, e.g. `Apache-2.0`. May be `NOASSERTION` for licenses
+    /// GitHub could not map to SPDX.
+    pub spdx_id: Option<String>,
+}
+
+/// Fetches repository metadata from the GitHub repos API.
+///
+/// Returns `None` if the repository does not exist.
+pub async fn repo_metadata(
+    owner: &str,
+    repo: &str,
+) -> Result<Option<RepoMetadata>, crate::ProviderError> {
+    let path = format!("repos/{}/{}", owner, repo);
+    match load_github_json(&path).await {
+        Ok(value) => serde_json::from_value(value).map(Some).map_err(|e| {
+            crate::ProviderError::ParseError(format!("Failed to parse repo metadata: {}", e))
+        }),
+        Err(HTTPJSONError::Error { status: 404, .. }) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+impl RepoMetadata {
+    /// Converts the repository metadata into upstream data items.
+    pub fn to_upstream_data(&self) -> Vec<UpstreamDatum> {
+        let mut results = Vec::new();
+        if let Some(description) = self.description.as_deref() {
+            if !description.is_empty() {
+                results.push(UpstreamDatum::Summary(description.to_string()));
+            }
+        }
+        if let Some(homepage) = self.homepage.as_deref() {
+            if !homepage.is_empty() {
+                results.push(UpstreamDatum::Homepage(homepage.to_string()));
+            }
+        }
+        if let Some(html_url) = self.html_url.as_deref() {
+            results.push(UpstreamDatum::Repository(html_url.to_string()));
+        }
+        if let Some(spdx) = self.license.as_ref().and_then(|l| l.spdx_id.as_deref()) {
+            if !spdx.is_empty() && spdx != "NOASSERTION" {
+                results.push(UpstreamDatum::License(spdx.to_string()));
+            }
+        }
+        results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_repo_metadata() {
+        let data = r#"{
+            "description": "Serialization framework for Rust",
+            "homepage": "https://serde.rs/",
+            "html_url": "https://github.com/serde-rs/serde",
+            "license": {"spdx_id": "Apache-2.0"},
+            "archived": false
+        }"#;
+        let meta: RepoMetadata = serde_json::from_str(data).unwrap();
+        assert_eq!(
+            meta.description.as_deref(),
+            Some("Serialization framework for Rust")
+        );
+        assert_eq!(
+            meta.license.as_ref().unwrap().spdx_id.as_deref(),
+            Some("Apache-2.0")
+        );
+
+        let data = meta.to_upstream_data();
+        assert_eq!(
+            data,
+            vec![
+                UpstreamDatum::Summary("Serialization framework for Rust".to_string()),
+                UpstreamDatum::Homepage("https://serde.rs/".to_string()),
+                UpstreamDatum::Repository("https://github.com/serde-rs/serde".to_string()),
+                UpstreamDatum::License("Apache-2.0".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_noassertion_license_dropped() {
+        let data = r#"{"license": {"spdx_id": "NOASSERTION"}}"#;
+        let meta: RepoMetadata = serde_json::from_str(data).unwrap();
+        assert_eq!(meta.to_upstream_data(), vec![]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@ static USER_AGENT: &str = concat!("upstream-ontologist/", env!("CARGO_PKG_VERSIO
 pub mod extrapolate;
 /// Support for various code forges (GitHub, GitLab, etc.)
 pub mod forges;
+/// GitHub API and raw file access helpers
+pub mod github;
 /// Homepage URL detection and validation
 pub mod homepage;
 /// HTTP utilities for fetching remote resources
@@ -1611,17 +1613,6 @@ pub async fn load_json_url(
     let mut headers = HeaderMap::new();
     headers.insert(reqwest::header::ACCEPT, "application/json".parse().unwrap());
 
-    if let Some(hostname) = http_url.host_str() {
-        if hostname == "github.com" || hostname == "raw.githubusercontent.com" {
-            if let Ok(token) = std::env::var("GITHUB_TOKEN") {
-                headers.insert(
-                    reqwest::header::WWW_AUTHENTICATE,
-                    format!("Bearer {}", token).parse().unwrap(),
-                );
-            }
-        }
-    }
-
     let client = crate::http::build_client()
         .default_headers(headers)
         .build()
@@ -1881,23 +1872,19 @@ impl Forge for GitHub {
             ));
         }
 
-        let api_url = Url::parse(&format!(
-            "https://api.github.com/repos/{}/{}",
-            path_elements[0], path_elements[1]
-        ))
-        .unwrap();
+        let api_path = format!("repos/{}/{}", path_elements[0], path_elements[1]);
 
-        let response = match reqwest::get(api_url).await {
-            Ok(response) => response,
-            Err(e) if e.status() == Some(reqwest::StatusCode::NOT_FOUND) => {
+        let data = match crate::github::load_github_json(&api_path).await {
+            Ok(data) => data,
+            Err(HTTPJSONError::Error { status: 404, .. }) => {
                 return Err(CanonicalizeError::InvalidUrl(
                     url.clone(),
-                    format!("Project does not exist {}", e),
+                    "Project does not exist".to_string(),
                 ));
             }
-            Err(e) if e.status() == Some(reqwest::StatusCode::FORBIDDEN) => {
+            Err(HTTPJSONError::Error { status: 403, .. }) => {
                 // Probably rate limited
-                warn!("Unable to verify bug database URL {}: {}", url, e);
+                warn!("Unable to verify bug database URL {}: rate limited", url);
                 return Err(CanonicalizeError::RateLimited(url.clone()));
             }
             Err(e) => {
@@ -1907,12 +1894,6 @@ impl Forge for GitHub {
                 ));
             }
         };
-        let data = response.json::<serde_json::Value>().await.map_err(|e| {
-            CanonicalizeError::Unverifiable(
-                url.clone(),
-                format!("Unable to verify bug database URL: {}", e),
-            )
-        })?;
 
         if data["has_issues"].as_bool() != Some(true) {
             return Err(CanonicalizeError::InvalidUrl(

--- a/src/providers/rust.rs
+++ b/src/providers/rust.rs
@@ -336,9 +336,6 @@ pub async fn load_crate_info(cratename: &str) -> Result<Option<CrateInfo>, crate
         .map_err(|e| crate::ProviderError::ParseError(format!("Failed to parse crate data: {}", e)))
 }
 
-/// Base URL of the crates.io sparse registry index (RFC 2789).
-const SPARSE_INDEX_URL: &str = "https://index.crates.io/";
-
 /// A dependency of a crate version, as recorded in the registry index.
 ///
 /// See <https://doc.rust-lang.org/cargo/reference/registry-index.html>.
@@ -411,10 +408,12 @@ pub struct IndexEntry {
     pub rust_version: Option<String>,
 }
 
-/// Computes the sparse index path for a crate name, per RFC 2789.
+/// Computes the registry index path for a crate name, per RFC 2789.
 ///
-/// Names are lower-cased and bucketed by length: 1-3 character names use
-/// dedicated prefixes, longer names are split into two-character directories.
+/// The same layout is used by the sparse index and the `crates.io-index` git
+/// mirror. Names are lower-cased and bucketed by length: 1-3 character names
+/// use dedicated prefixes, longer names are split into two-character
+/// directories.
 fn index_path(name: &str) -> String {
     let lower = name.to_lowercase();
     match lower.len() {
@@ -425,7 +424,11 @@ fn index_path(name: &str) -> String {
     }
 }
 
-/// Loads all version entries for a crate from the crates.io sparse index.
+/// Loads all version entries for a crate from the crates.io registry index.
+///
+/// The index data is fetched from the `rust-lang/crates.io-index` repository on
+/// GitHub, which mirrors the same per-crate metadata as the sparse index at
+/// [`index.crates.io`](https://index.crates.io/).
 ///
 /// Returns `None` if the crate is not present in the index. The entries are
 /// returned in the order they appear in the index, which is publication order
@@ -433,30 +436,18 @@ fn index_path(name: &str) -> String {
 pub async fn load_index_info(
     cratename: &str,
 ) -> Result<Option<Vec<IndexEntry>>, crate::ProviderError> {
-    let url = format!("{}{}", SPARSE_INDEX_URL, index_path(cratename));
-
-    let client = crate::http::build_client()
-        .build()
-        .map_err(|e| crate::ProviderError::Other(e.to_string()))?;
-
-    let response = client
-        .get(&url)
-        .send()
-        .await
-        .map_err(|e| crate::ProviderError::Other(e.to_string()))?;
-
-    if response.status() == reqwest::StatusCode::NOT_FOUND {
-        return Ok(None);
-    }
-
-    let response = response
-        .error_for_status()
-        .map_err(|e| crate::ProviderError::Other(e.to_string()))?;
-
-    let body = response
-        .text()
-        .await
-        .map_err(|e| crate::ProviderError::Other(e.to_string()))?;
+    let body = match crate::github::download_raw_file(
+        "rust-lang",
+        "crates.io-index",
+        "master",
+        &index_path(cratename),
+    )
+    .await
+    {
+        Ok(body) => body,
+        Err(crate::HTTPJSONError::Error { status: 404, .. }) => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
 
     let mut entries = Vec::new();
     for line in body.lines() {

--- a/src/providers/rust.rs
+++ b/src/providers/rust.rs
@@ -336,6 +336,142 @@ pub async fn load_crate_info(cratename: &str) -> Result<Option<CrateInfo>, crate
         .map_err(|e| crate::ProviderError::ParseError(format!("Failed to parse crate data: {}", e)))
 }
 
+/// Base URL of the crates.io sparse registry index (RFC 2789).
+const SPARSE_INDEX_URL: &str = "https://index.crates.io/";
+
+/// A dependency of a crate version, as recorded in the registry index.
+///
+/// See <https://doc.rust-lang.org/cargo/reference/registry-index.html>.
+#[derive(Deserialize, Debug, Clone)]
+pub struct IndexDependency {
+    /// Name of the dependency (the renamed name if it was renamed).
+    pub name: String,
+    /// SemVer requirement for this dependency.
+    pub req: String,
+    /// Features enabled for this dependency.
+    #[serde(default)]
+    pub features: Vec<String>,
+    /// Whether this is an optional dependency.
+    #[serde(default)]
+    pub optional: bool,
+    /// Whether the dependency's default features are enabled.
+    #[serde(default = "default_true")]
+    pub default_features: bool,
+    /// Target platform expression this dependency applies to, if any.
+    #[serde(default)]
+    pub target: Option<String>,
+    /// Dependency kind: `normal`, `dev` or `build`.
+    #[serde(default)]
+    pub kind: Option<String>,
+    /// Registry index URL, or `None` for the current registry.
+    #[serde(default)]
+    pub registry: Option<String>,
+    /// Original package name if the dependency was renamed.
+    #[serde(default)]
+    pub package: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// A single crate version entry from the crates.io sparse index.
+///
+/// The sparse index only carries the data needed for dependency resolution
+/// (name, version, dependencies, features, checksum). It does not include the
+/// rich metadata served by the crates.io REST API such as the homepage,
+/// repository, description or license; use [`load_crate_info`] for those.
+#[derive(Deserialize, Debug, Clone)]
+pub struct IndexEntry {
+    /// Name of the crate.
+    pub name: String,
+    /// Version of this entry.
+    pub vers: semver::Version,
+    /// Dependencies of this version.
+    pub deps: Vec<IndexDependency>,
+    /// SHA256 checksum of the `.crate` file.
+    pub cksum: String,
+    /// Map of feature names to the features or dependencies they enable.
+    #[serde(default)]
+    pub features: HashMap<String, Vec<String>>,
+    /// Map of features using the 1.60+ extended syntax, if present.
+    #[serde(default)]
+    pub features2: Option<HashMap<String, Vec<String>>>,
+    /// Whether this version has been yanked.
+    #[serde(default)]
+    pub yanked: bool,
+    /// The `links` value from the manifest, if any.
+    #[serde(default)]
+    pub links: Option<String>,
+    /// Schema version of this entry, defaulting to 1.
+    #[serde(default)]
+    pub v: Option<u32>,
+    /// Minimum supported Rust version, if declared.
+    #[serde(default)]
+    pub rust_version: Option<String>,
+}
+
+/// Computes the sparse index path for a crate name, per RFC 2789.
+///
+/// Names are lower-cased and bucketed by length: 1-3 character names use
+/// dedicated prefixes, longer names are split into two-character directories.
+fn index_path(name: &str) -> String {
+    let lower = name.to_lowercase();
+    match lower.len() {
+        1 => format!("1/{}", lower),
+        2 => format!("2/{}", lower),
+        3 => format!("3/{}/{}", &lower[..1], lower),
+        _ => format!("{}/{}/{}", &lower[..2], &lower[2..4], lower),
+    }
+}
+
+/// Loads all version entries for a crate from the crates.io sparse index.
+///
+/// Returns `None` if the crate is not present in the index. The entries are
+/// returned in the order they appear in the index, which is publication order
+/// (oldest first).
+pub async fn load_index_info(
+    cratename: &str,
+) -> Result<Option<Vec<IndexEntry>>, crate::ProviderError> {
+    let url = format!("{}{}", SPARSE_INDEX_URL, index_path(cratename));
+
+    let client = crate::http::build_client()
+        .build()
+        .map_err(|e| crate::ProviderError::Other(e.to_string()))?;
+
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| crate::ProviderError::Other(e.to_string()))?;
+
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+
+    let response = response
+        .error_for_status()
+        .map_err(|e| crate::ProviderError::Other(e.to_string()))?;
+
+    let body = response
+        .text()
+        .await
+        .map_err(|e| crate::ProviderError::Other(e.to_string()))?;
+
+    let mut entries = Vec::new();
+    for line in body.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let entry: IndexEntry = serde_json::from_str(line).map_err(|e| {
+            crate::ProviderError::ParseError(format!("Failed to parse index entry: {}", e))
+        })?;
+        entries.push(entry);
+    }
+
+    Ok(Some(entries))
+}
+
 // TODO: dedupe with TryFrom implementation above
 fn parse_crates_io(data: &CrateInfo) -> Vec<UpstreamDatum> {
     let crate_data = &data.crate_;
@@ -421,5 +557,29 @@ mod crates_io_tests {
         let crate_info: CrateInfo = serde_json::from_str(data).unwrap();
 
         assert_eq!(crate_info.crate_.name, "breezy");
+    }
+
+    #[test]
+    fn test_index_path() {
+        assert_eq!(index_path("a"), "1/a");
+        assert_eq!(index_path("ab"), "2/ab");
+        assert_eq!(index_path("abc"), "3/a/abc");
+        assert_eq!(index_path("serde"), "se/rd/serde");
+        assert_eq!(index_path("Inflector"), "in/fl/inflector");
+        assert_eq!(index_path("cargo-edit"), "ca/rg/cargo-edit");
+    }
+
+    #[test]
+    fn test_parse_index_entry() {
+        let line = r#"{"name":"serde","vers":"1.0.0","deps":[{"name":"serde_derive","req":"^1.0","features":[],"optional":true,"default_features":true,"target":null,"kind":"normal"}],"cksum":"00000000000000000000000000000000000000000000000000000000000000aa","features":{"derive":["serde_derive"],"default":["std"]},"yanked":false}"#;
+
+        let entry: IndexEntry = serde_json::from_str(line).unwrap();
+
+        assert_eq!(entry.name, "serde");
+        assert_eq!(entry.vers, semver::Version::new(1, 0, 0));
+        assert_eq!(entry.deps.len(), 1);
+        assert_eq!(entry.deps[0].name, "serde_derive");
+        assert!(entry.deps[0].optional);
+        assert!(!entry.yanked);
     }
 }

--- a/src/vcs.rs
+++ b/src/vcs.rs
@@ -113,15 +113,8 @@ pub fn strip_vcs_prefixes(url: &str) -> &str {
 async fn probe_upstream_github_branch_url(url: &url::Url, version: Option<&str>) -> Option<bool> {
     let path = url.path();
     let path = path.strip_suffix(".git").unwrap_or(path);
-    let api_url = url::Url::parse(
-        format!(
-            "https://api.github.com/repos/{}/tags",
-            path.trim_start_matches('/')
-        )
-        .as_str(),
-    )
-    .unwrap();
-    match crate::load_json_url(&api_url, None).await {
+    let api_path = format!("repos/{}/tags", path.trim_start_matches('/'));
+    match crate::github::load_github_json(&api_path).await {
         Ok(json) => {
             if let Some(version) = version {
                 let tags = json.as_array()?;
@@ -254,11 +247,8 @@ pub async fn check_repository_url_canonical(
         }
 
         segments[1] = segments[1].trim_end_matches(".git");
-        let api_url = format!(
-            "https://api.github.com/repos/{}/{}",
-            segments[0], segments[1]
-        );
-        url = match crate::load_json_url(&url::Url::parse(api_url.as_str()).unwrap(), None).await {
+        let api_path = format!("repos/{}/{}", segments[0], segments[1]);
+        url = match crate::github::load_github_json(&api_path).await {
             Ok(data) => {
                 if data["archived"].as_bool().unwrap_or(false) {
                     return Err(crate::CanonicalizeError::InvalidUrl(


### PR DESCRIPTION
either use index.crates.io or the GitHub repository contents (for full metadata)

Fixes #555